### PR TITLE
ci: yarn engine version use caret ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "*.css"
   ],
   "engines": {
-    "yarn": ">=1.21.1 <=1.22.18"
+    "yarn": "^1.21.1"
   },
   "scripts": {
     "size": "yarn icons-build && size-limit",


### PR DESCRIPTION
Сборки будут ломаться, т.к. раннеры переходят на [Yarn 1.22.19](https://github.com/actions/virtual-environments/blob/ubuntu20/20220614.0/images/linux/Ubuntu2004-Readme.md#:~:text=Yarn%201.22.19)