### PR TITLE
feat: move icons to use `fontSize`

### DIFF
--- a/packages/icons-scripts/scripts/reactify.js
+++ b/packages/icons-scripts/scripts/reactify.js
@@ -2,9 +2,17 @@ const Compiler = require('svg-baker');
 
 const compiler = new Compiler();
 
+function pxToEm(pxSize, baseSize) {
+  return `${Number((pxSize / baseSize).toFixed(4))}em`;
+}
+
 const reactify = (symbol, componentName) => {
-  const width = symbol.viewBox.split(' ')[2];
-  const height = symbol.viewBox.split(' ')[3];
+  const defaultWidth = Number(symbol.viewBox.split(' ')[2]);
+  const defaultHeight = Number(symbol.viewBox.split(' ')[3]);
+
+  const baseSize = Math.max(defaultWidth, defaultHeight);
+  const relativeWidth = pxToEm(defaultWidth, baseSize);
+  const relativeHeight = pxToEm(defaultHeight, baseSize);
 
   return `import { HTMLAttributes, RefCallback, RefObject } from 'react';
 import { makeIcon } from '../SvgIcon';
@@ -20,9 +28,12 @@ export default makeIcon<${componentName}Props>(
   '${componentName}',
   '${symbol.id}',
   '${symbol.viewBox}',
-  '${symbol.render()}',
-  ${width},
-  ${height}
+  ${defaultWidth},
+  ${defaultHeight},
+  '${relativeWidth}',
+  '${relativeHeight}',
+  ${baseSize},
+  '${symbol.render()}'
 );
 `;
 };

--- a/packages/icons-scripts/scripts/reactify.js
+++ b/packages/icons-scripts/scripts/reactify.js
@@ -7,12 +7,12 @@ function pxToEm(pxSize, baseSize) {
 }
 
 const reactify = (symbol, componentName) => {
-  const defaultWidth = Number(symbol.viewBox.split(' ')[2]);
-  const defaultHeight = Number(symbol.viewBox.split(' ')[3]);
+  const viewBoxWidth = Number(symbol.viewBox.split(' ')[2]);
+  const viewBoxHeight = Number(symbol.viewBox.split(' ')[3]);
 
-  const baseSize = Math.max(defaultWidth, defaultHeight);
-  const relativeWidth = pxToEm(defaultWidth, baseSize);
-  const relativeHeight = pxToEm(defaultHeight, baseSize);
+  const fontSize = Math.max(viewBoxWidth, viewBoxHeight);
+  const fontSizeWidth = pxToEm(viewBoxWidth, fontSize);
+  const fontSizeHeight = pxToEm(viewBoxHeight, fontSize);
 
   return `import { HTMLAttributes, RefCallback, RefObject } from 'react';
 import { makeIcon } from '../SvgIcon';
@@ -28,11 +28,11 @@ export default makeIcon<${componentName}Props>(
   '${componentName}',
   '${symbol.id}',
   '${symbol.viewBox}',
-  ${defaultWidth},
-  ${defaultHeight},
-  '${relativeWidth}',
-  '${relativeHeight}',
-  ${baseSize},
+  ${viewBoxWidth},
+  ${viewBoxHeight},
+  ${fontSize},
+  '${fontSizeWidth}',
+  '${fontSizeHeight}',
   '${symbol.render()}'
 );
 `;

--- a/packages/icons-scripts/src/SvgIcon.tsx
+++ b/packages/icons-scripts/src/SvgIcon.tsx
@@ -4,6 +4,7 @@ import BrowserSymbol from 'svg-baker-runtime/browser-symbol';
 import { IconSettingsInterface, IconSettingsContext } from './IconSettings';
 import { addSpriteSymbol, useIsomorphicLayoutEffect } from './sprite';
 
+/** @public */
 export interface SvgIconProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Для пропорционального изменения размера иконки относительно размера шрифта.
@@ -21,11 +22,12 @@ export interface SvgIconProps extends React.HTMLAttributes<HTMLDivElement> {
   Component?: React.ElementType,
 }
 
+/** @private */
 interface SvgIconInternalProps extends SvgIconProps {
-  defaultWidth: number;
-  defaultHeight: number;
-  relativeWidth: string;
-  relativeHeight: string;
+  viewBoxWidth: number;
+  viewBoxHeight: number;
+  fontSizeWidth: string;
+  fontSizeHeight: string;
 }
 
 const svgStyle = { display: 'block' };
@@ -45,12 +47,12 @@ function iconClass(fragments: string[], { classPrefix, globalClasses }: IconSett
 
 const SvgIcon: React.FC<SvgIconInternalProps> = ({
   /**
-   * Внутренние параметры (скрыты от пользователя)
+   * Внутренние параметры (скрыты от пользователя).
    */
-  defaultWidth,
-  defaultHeight,
-  relativeWidth,
-  relativeHeight,
+  viewBoxWidth,
+  viewBoxHeight,
+  fontSizeWidth,
+  fontSizeHeight,
 
   /**
    * Пользовательские параметры.
@@ -72,13 +74,13 @@ const SvgIcon: React.FC<SvgIconInternalProps> = ({
 }) => {
   const iconSettings = React.useContext(IconSettingsContext);
 
-  const classNameWidth = widthProp || defaultWidth;
-  const classNameHeight = heightProp || defaultHeight;
+  const classNameWidth = widthProp || viewBoxWidth;
+  const classNameHeight = heightProp || viewBoxHeight;
   const classNameSize = Math.max(classNameWidth, classNameHeight);
   const ownClass = iconClass(['Icon', `Icon--${classNameSize}`, `Icon--w-${classNameWidth}`, `Icon--h-${classNameHeight}`, `Icon--${id}`], iconSettings);
 
-  const width = widthProp || relativeWidth;
-  const height = heightProp || relativeHeight;
+  const width = widthProp || fontSizeWidth;
+  const height = heightProp || fontSizeHeight;
 
   return (
     <Component
@@ -106,25 +108,25 @@ const SvgIcon: React.FC<SvgIconInternalProps> = ({
 export function makeIcon<Props extends SvgIconProps = SvgIconProps>(
   componentName: string,
   id: string,
-  defaultViewBox: string,
-  defaultWidth: number,
-  defaultHeight: number,
-  relativeWidth: string,
-  relativeHeight: string,
-  defaultFontSize: number,
+  viewBox: string,
+  viewBoxWidth: number,
+  viewBoxHeight: number,
+  fontSize: number,
+  fontSizeWidth: string,
+  fontSizeHeight: string,
   content: string,
 ): React.FC<Props> {
   let isMounted = false;
   function mountIcon() {
     if (!isMounted) {
-      addSpriteSymbol(new BrowserSymbol({ id, viewBox: defaultViewBox, content }));
+      addSpriteSymbol(new BrowserSymbol({ id, viewBox, content }));
       isMounted = true;
     }
   }
 
   const Icon: React.FC<Props> = ({
-    viewBox = defaultViewBox,
-    fontSize = defaultFontSize,
+    viewBox: viewBoxProp = viewBox,
+    fontSize: fontSizeProp = fontSize,
     ...restProps
   }) => {
     useIsomorphicLayoutEffect(mountIcon, []);
@@ -132,13 +134,13 @@ export function makeIcon<Props extends SvgIconProps = SvgIconProps>(
     return (
       <SvgIcon
         {...restProps}
+        viewBox={viewBoxProp}
+        fontSize={fontSizeProp}
         id={id}
-        viewBox={viewBox}
-        defaultWidth={defaultWidth}
-        defaultHeight={defaultHeight}
-        relativeWidth={relativeWidth}
-        relativeHeight={relativeHeight}
-        fontSize={fontSize}
+        viewBoxWidth={viewBoxWidth}
+        viewBoxHeight={viewBoxHeight}
+        fontSizeWidth={fontSizeWidth}
+        fontSizeHeight={fontSizeHeight}
       />
     )
   };

--- a/src/docs/docs.js
+++ b/src/docs/docs.js
@@ -21,7 +21,16 @@ const example =
 
 <Icon24Cancel />`;
 
-const sizeExample = `<Icon24LogoVk width={20} height={20} />`;
+const sizeExampleFontSizeInherit =
+`<p style={{ fontSize: 16 }>
+  <a href="https://google.com" target="_blank">
+      https://google.com <Icon24ExternalLinkOutline fontSize="inherit" />
+  </a>
+</p>`;
+
+const sizeExampleFontSizeFix = `<Icon24LogoVk fontSize={20} />`;
+
+const sizeExampleFixSize = `<Icon16MoreVertical width={12} height={24} />`;
 
 class Docs extends React.PureComponent {
   constructor (props) {
@@ -87,10 +96,32 @@ class Docs extends React.PureComponent {
         <pre>{example}</pre>
         <h2>Кастомные размеры</h2>
         <p>
-          Иногда может потребоваться установить для иконки другой размер.
-          Для этого можно передать свойства <code>width</code> и <code>height</code>, ширина и высота в пикселях. <b>Они должны быть числовыми значениями.</b>
+          Иногда может потребоваться установить для иконки другой размер. Для этого используйте параметр
+          {" "}<code>fontSize</code>, который принимает все валидные для него значения.
         </p>
-        <pre>{sizeExample}</pre>
+        <p>
+          Например, иконка вставлена в блок с текстом и, для лучшего выравнивания, нам нужно, чтобы она имела размер,
+          равный высоте текста. Мы добьёмся этого передав <code>fontSize="inherit"</code> или
+          {" "}<code>fontSize="1em"</code>:
+        </p>
+        <pre>{sizeExampleFontSizeInherit}</pre>
+        <p>
+          А вот пример с фиксированным размером иконки:
+        </p>
+        <pre>{sizeExampleFontSizeFix}</pre>
+        <br />
+        <p>
+          Также можно изменить размер через параметры <code>width</code> и <code>height</code>. Нюансы:
+
+          <ol>
+            <li>значения должны быть <b>числовыми</b>;</li>
+            <li>следует соблюсти <b>соотношение сторон</b> (см. <code>viewBox</code> конкретной иконки);</li>
+            <li>параметр <code>fontSize</code> больше не будет играть роли</li>
+          </ol>
+
+          Пример:
+        </p>
+        <pre>{sizeExampleFixSize}</pre>
         <h2>Стилизация</h2>
         <div className="color">
           <p>


### PR DESCRIPTION
Все подробности в issue #237.

## Разъяснение решений

1. Создал внутренние параметры `fontSizeWidth`/`fontSizeHeight`, чтобы высчитывание было один раз вне рантайма (см. `pxToEm()` в файле `scripts/reactify.js`).
2. Создал внутренние параметры `viewBoxWidth`/`viewBoxHeight`, которые всегда числовые и совпадают с `viewBox`, т.к. `width`/`height` у `SvgIcon` изначально не должны быть определены:
    1. Так мы понимаем использовать `fontSizeWidth`/`fontSizeHeight` или нет.
    2. Выставляем модификаторы с размерами в `className` на основе `viewBoxWidth`/`viewBoxHeight`.

    Передача `width`/`height` эти два момента перебьёт.
    > PS: Можно парсить `viewBox`, но это, кмк, оверхед операция, лучше уж отдельный примитив передавать.

## Дополнительно

Поправил в документации заголовок под названием **Кастомные размеры**

<img width="1254" alt="image" src="https://user-images.githubusercontent.com/5850354/183897996-cbfdd47d-55fa-4f8d-bf50-df7e68d6a777.png">

---

- close #237 
- close #131