### PR TITLE
[BREAKING CHANGES] Убираем корневой div из иконок

### DIFF
--- a/packages/icons-scripts/scripts/reactify.js
+++ b/packages/icons-scripts/scripts/reactify.js
@@ -16,14 +16,14 @@ const reactify = (symbol, componentName, deprecated, replacement) => {
 `;
   }
 
-  return `import { HTMLAttributes, RefCallback, RefObject } from 'react';
+  return `import { HTMLAttributes, Ref } from 'react';
 import { makeIcon } from '../SvgIcon';
 
-export interface ${componentName}Props extends HTMLAttributes<HTMLDivElement> {
+export interface ${componentName}Props extends HTMLAttributes<SVGSVGElement> {
   fill?: string;
   width?: number;
   height?: number;
-  getRootRef?: RefCallback<HTMLDivElement> | RefObject<HTMLDivElement>;
+  getRef?: Ref<SVGSVGElement>;
   deprecated?: boolean;
   replacement?: string;
 }

--- a/packages/icons-scripts/src/SvgIcon.tsx
+++ b/packages/icons-scripts/src/SvgIcon.tsx
@@ -5,16 +5,13 @@ import { IconSettingsInterface, IconSettingsContext } from './IconSettings';
 import { addSpriteSymbol, useIsomorphicLayoutEffect } from './sprite';
 import { warnOnce } from './warnOnce';
 
-export interface SvgIconProps extends React.HTMLAttributes<HTMLDivElement> {
+export interface SvgIconProps extends React.HTMLAttributes<SVGSVGElement> {
   width?: number;
   height?: number;
   viewBox?: string;
   fill?: string;
-  getRootRef?: React.RefCallback<HTMLDivElement> | React.RefObject<HTMLDivElement>;
-  Component?: React.ElementType;
+  getRef?: React.Ref<SVGSVGElement>;
 }
-
-const svgStyle = { display: 'block' };
 
 function iconClass(fragments: string[], { classPrefix, globalClasses }: IconSettingsInterface) {
   let res = '';
@@ -37,11 +34,8 @@ const SvgIcon: React.FC<SvgIconProps> = ({
   className = '',
   style = {},
   fill,
-  getRootRef,
-  Component = 'div',
-  role,
-  'aria-label': ariaLabel,
-  'aria-hidden': ariaHidden,
+  getRef,
+  role = 'presentation',
   ...restProps
 }) => {
   const size = Math.max(width, height);
@@ -53,25 +47,18 @@ const SvgIcon: React.FC<SvgIconProps> = ({
   );
 
   return (
-    <Component
+    <svg
       role="presentation"
       {...restProps}
-      ref={getRootRef}
       className={`${ownClass} ${className}`}
-      style={{ ...style, width, height }}
+      viewBox={viewBox}
+      width={width}
+      height={height}
+      style={{ ...style, display: 'block', width, height }}
+      ref={getRef}
     >
-      <svg
-        viewBox={viewBox}
-        width={width}
-        height={height}
-        style={svgStyle}
-        role={role}
-        aria-label={ariaLabel}
-        aria-hidden={ariaHidden}
-      >
-        <use xlinkHref={`#${id}`} style={{ fill: 'currentColor', color: fill }} />
-      </svg>
-    </Component>
+      <use xlinkHref={`#${id}`} style={{ fill: 'currentColor', color: fill }} />
+    </svg>
   );
 };
 

--- a/packages/icons-scripts/src/SvgIcon.tsx
+++ b/packages/icons-scripts/src/SvgIcon.tsx
@@ -35,7 +35,6 @@ const SvgIcon: React.FC<SvgIconProps> = ({
   style = {},
   fill,
   getRef,
-  role = 'presentation',
   ...restProps
 }) => {
   const size = Math.max(width, height);
@@ -48,7 +47,7 @@ const SvgIcon: React.FC<SvgIconProps> = ({
 
   return (
     <svg
-      role="presentation"
+      aria-hidden="true"
       {...restProps}
       className={`${ownClass} ${className}`}
       viewBox={viewBox}


### PR DESCRIPTION
- resolves #133 

Заодно поправила нюанс с доступностью: кажется, что `aria-hidden` все же лучше `role="presentation"` для наших целей, т.к. иконки в большинстве случаев нужно в принципе скрывать от скринридера. Перебить при необходимости легко, передав свой `aria-hidden`.