### PR TITLE
fix(icons, icons-scripts): update types; make it possible to override default `style` tag

### DIFF
--- a/packages/icons-scripts/scripts/reactify.js
+++ b/packages/icons-scripts/scripts/reactify.js
@@ -24,6 +24,7 @@ export interface ${componentName}Props extends SVGProps<SVGSVGElement> {
   width?: number;
   height?: number;
   getRootRef?: Ref<SVGSVGElement>;
+  title?: string;
   deprecated?: boolean;
   replacement?: string;
 }

--- a/packages/icons-scripts/src/SvgIcon.tsx
+++ b/packages/icons-scripts/src/SvgIcon.tsx
@@ -9,6 +9,7 @@ export interface SvgIconProps extends React.SVGProps<SVGSVGElement> {
   width?: number;
   height?: number;
   getRootRef?: React.Ref<SVGSVGElement>;
+  title?: string;
 }
 
 function iconClass(fragments: string[], { classPrefix, globalClasses }: IconSettingsInterface) {
@@ -33,6 +34,7 @@ const SvgIcon = ({
   style = {},
   fill,
   getRootRef,
+  title,
   ...restProps
 }: SvgIconProps) => {
   const size = Math.max(width, height);
@@ -54,6 +56,7 @@ const SvgIcon = ({
       style={{ ...style, display: 'block', width, height }}
       ref={getRootRef}
     >
+      {title && <title>{title}</title>}
       <use xlinkHref={`#${id}`} style={{ fill: 'currentColor', color: fill }} />
     </svg>
   );

--- a/packages/icons-scripts/src/SvgIcon.tsx
+++ b/packages/icons-scripts/src/SvgIcon.tsx
@@ -31,9 +31,9 @@ const SvgIcon = ({
   viewBox,
   id,
   className = '',
-  style = {},
   fill,
   getRootRef,
+  style: propsStyle = {},
   title,
   ...restProps
 }: SvgIconProps) => {
@@ -45,6 +45,13 @@ const SvgIcon = ({
     iconSettings,
   );
 
+  const style = {
+    display: 'block',
+    width,
+    height,
+    ...propsStyle,
+  };
+
   return (
     <svg
       aria-hidden="true"
@@ -53,7 +60,7 @@ const SvgIcon = ({
       viewBox={viewBox}
       width={width}
       height={height}
-      style={{ ...style, display: 'block', width, height }}
+      style={style}
       ref={getRootRef}
     >
       {title && <title>{title}</title>}


### PR DESCRIPTION
- добавила `title`,
- вытащила и улучшила полезную штуку от @SevereCloud из #306 (https://github.com/VKCOM/icons/pull/306/commits/b98094e3ab63fd9003827ad3b5831eafbfdf1915): оставила дефолтные стили, но даю их перебить при необходимости