### PR TITLE
feat(GitHub Actions):  переиспользует `npm_deprecate_package` воркфлоу

### DIFF
--- a/.github/workflows/npm_deprecate_package.yml
+++ b/.github/workflows/npm_deprecate_package.yml
@@ -1,0 +1,24 @@
+name: 'Deprecate NPM package'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'type version: x.y.z (without "v")'
+        required: true
+      reason:
+        description: 'reason for deprecation (only latin supported)'
+        required: true
+
+run-name: Deprecate @vkontakte/icons@${{ inputs.version }}
+
+jobs:
+  deprecate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: VKCOM/.github/.github/workflows/npm_deprecate_package.yml@main
+        with:
+          package: '@vkontakte/icons'
+          version: ${{ inputs.version }}
+          reason: ${{ inputs.reason }}
+          auth_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}


### PR DESCRIPTION
Используем https://github.com/VKCOM/.github/blob/main/.github/workflows/npm_deprecate_package.yml для депрекейта пакетов в NPM

---

- related to https://github.com/VKCOM/.github/issues/1
- [GitHub • Reusing workflows
](https://docs.github.com/en/actions/using-workflows/reusing-workflows#example-reusable-workflow)