### PR TITLE
fix(GitHub Actions): remove steps field in `npm_deprecate_package` workflow

### DIFF
--- a/.github/workflows/npm_deprecate_package.yml
+++ b/.github/workflows/npm_deprecate_package.yml
@@ -14,11 +14,9 @@ run-name: Deprecate @vkontakte/icons@${{ inputs.version }}
 
 jobs:
   deprecate:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: VKCOM/.github/.github/workflows/npm_deprecate_package.yml@main
-        with:
-          package: '@vkontakte/icons'
-          version: ${{ inputs.version }}
-          reason: ${{ inputs.reason }}
-          auth_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}
+    uses: VKCOM/.github/.github/workflows/npm_deprecate_package.yml@main
+    with:
+      package: '@vkontakte/icons'
+      version: ${{ inputs.version }}
+      reason: ${{ inputs.reason }}
+      auth_token: ${{ secrets.NPMJS_PUBLISH_TOKEN }}


### PR DESCRIPTION
> етить его колотить этот копипаст 🤦‍♂️

из-за копипаста, вызов воркфлоу в `steps` попал, что невалидно

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/214293259-4a3e8c45-8b03-46fb-9c99-8571b8efc2cf.png">

_https://github.com/VKCOM/icons/actions/runs/3996096116_

---

- caused by #330