### PR TITLE
ci(pull_request.yml): fix dependabot permissions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,12 @@ name: 'Pull Request'
 
 on: ['pull_request']
 
+# Для расширения доступа Dependabot
+#
+# https://github.com/peter-evans/create-or-update-comment/issues/103
+permissions:
+  pull-requests: write
+
 jobs:
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Проблема

По умолчанию у Dependabot права только на чтение, из-за чего падает джоба `peter-evans/create-or-update-comment`

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/219403299-03b1db6a-f80f-4e25-bebc-e3d5947072e1.png">

**Рис. 1** https://github.com/VKCOM/icons/actions/runs/4186867441/jobs/7255975802

## Решение

В этом issue https://github.com/peter-evans/create-or-update-comment/issues/103#issuecomment-1041057863 подсказывают, что надо для Dependabot надо дать права на запись