### PR TITLE
Fix extra category icons with similar file name prefix and different size

### DIFF
--- a/packages/icons-scripts/scripts/icons-map.js
+++ b/packages/icons-scripts/scripts/icons-map.js
@@ -80,6 +80,7 @@ function dirMap(src, pattern, prefix = '', deprecatedIcons) {
       deprecated,
       replacement: deprecated ? getReplacementIconComponentName(deprecatedIcons[name]) : undefined,
       content,
+      size,
     };
   });
 }

--- a/packages/icons-scripts/scripts/icons.js
+++ b/packages/icons-scripts/scripts/icons.js
@@ -56,6 +56,7 @@ function generateIcons(options) {
           width,
           height,
           dirname,
+          size,
         } = icon;
 
         // Превращаем svg-файл в ts-файл в виде строки
@@ -78,8 +79,9 @@ function generateIcons(options) {
           fs.mkdirSync(iconDir);
         }
 
-        fs.writeFileSync(path.join(iconDir, `${id}.ts`), reactSource);
-        exportsMap[exportName] = `./${dirname}/${id}`;
+        const fileName = `${id}${size ? `_${size}` : ''}`;
+        fs.writeFileSync(path.join(iconDir, `${fileName}.ts`), reactSource);
+        exportsMap[exportName] = `./${dirname}/${fileName}`;
       });
 
       debugInfo('Creating index.ts file with exports');


### PR DESCRIPTION
Пока тестировал пакет `@vkontakte/icons-scripts` после переезда в монорепу, нашел багу.

## Пример.
`@vkontakte/icons-scripts` используется в проекте, структура которого, имеет кроме папок  с размерами 
`/src/svg/20/*,` `/src/svg/40`, ещё и уникальные имена папок с иконками типа `/src/svg/Unsorted/`.
Одинковые иконки, разного размера, в такой папке могут иметь имена типа, 
```sh
  /src/svg/Unsorted/live_badge_14.svg
  /src/svg/Unsorted/live_badge_18.svg
```

> Мы собираем иконки из этой папки (`/src/svg/Unsorted/`) потому что `generateIcons()` принимает опцию `extraCategories`, которая по умолчанию имеет значение `["Unsorted"].
https://github.com/VKCOM/icons/blob/f8ba56cd00cca9db87579440417d9ed50c4880b1/packages/icons-scripts/scripts/options.js#L31

Текущая версия `@vkontakte/icons-scripts` упадет при сборке с ошибкой:
```sh
ts/index.ts(19,10): error TS2724: '"./Unsorted/live_badge"' has no exported member named 'Icon14LiveBadge'. Did you mean 'Icon18LiveBadge'?\n` +
```

Всё потому, что такие иконки будут записаны в один файл, и одна перезапишет другую.
```sh
/ts/Unsorted/live_badge.ts
```
И в файле `/ts/Unsorted/live_badge.ts` останется только `Icon18LiveBadge`.

Хотя в файле `/ts/index.ts` будут экспортированы обе иконки из одного файла.
```js
  export { Icon14LiveBadge } from './Unsorted/live_badge'; // <-- error !!!
  export { Icon18LiveBadge } from './Unsorted/live_badge'; 
```

## Решение (в лоб)
Добавлять именам файлов postfix `_${size}`.

Билд не будет падать и все иконки будут верно экспортироваться.
Негативный эффект от этого, правда, в том, что очень многие файлы в `/dist` и `/ts` будут иметь постфиксы, даже те, которые лежат по папкам с размерами.
```
  /ts/20/badge_20.ts
  /dist/20/badge_20.js
  /dist/Unsorted/live_badge_14.js
  /dist/Unsorted/live_badge_18.js
```

<h2 id="version-2">По поводу версии **v2.0.0** пакета `@vkontakte/icons-scripts`. </h2>
Там тоже есть эта проблема, но в версии **v2.0.0** иконки из ts/index.ts экспортируются иначе, там мы экспортируем `defaults`.
```ts
export { default as Icon14LiveBadge } from './Unsorted/live_badge';
export { default as Icon18LiveBadge } from './Unsorted/live_badge';
```

В результате чего ts не падает, и иконки собираются, но компоненты `Icon14LiveBadge` и `Icon18LiveBadge` это одна и та же иконка `Icon18LiveBadge`.


---

Код экспорта версии **v2.0.0**
https://github.com/VKCOM/icons/blob/6fd8e1e47dc89bfb5239216f961f31ce1f4fe8d2/packages/icons-scripts/scripts/icons.js#L135

Код экспорта версии **v3.0.0**
https://github.com/VKCOM/icons/blob/6e17d3e96e20439773cf912d6b0404e7277ae65e/packages/icons-scripts/scripts/icons.js#L160


