### PR TITLE
Fix path to docs build results for github-pages-deploy action

### DIFF
--- a/.github/workflows/publish_icons.yml
+++ b/.github/workflows/publish_icons.yml
@@ -118,6 +118,6 @@ jobs:
         with:
           token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
           branch: gh-pages
-          folder: docs
+          folder: packages/icons/docs
           clean: false
           force: false


### PR DESCRIPTION
Follow up: https://github.com/VKCOM/icons/pull/588

Похоже что экшен, отвечающий за публикацию документации для иконок смотрит в рутовую папку репозитория, не в воркспейс.
Моя ошибка, с чего-то взял, что раз `workingDirectory` для workflow задан для всех шагов, то и экшены используемые внутри будут отталкиватья от `workingDirectory`.