### PR TITLE
dependabot: use groups; set all schedule to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,16 +19,29 @@ updates:
     groups:
       jest:
         patterns:
-          - 'jest'
-          - 'jest-environment-*'
-      size-limit:
+          - 'jest*'
+          - '@swc/jest'
+      webpack:
         patterns:
-          - 'size-limit'
-          - '@size-limit/*'
+          - 'webpack'
+          - 'html-webpack-plugin'
+          - 'file-loader'
+          - 'css-loader'
+          - 'style-loader'
+          - 'swc-loader'
       react:
         patterns:
           - 'react'
           - 'react-dom'
+          - '@types/react'
+      size-limit:
+        patterns:
+          - 'size-limit'
+          - '@size-limit/*'
+      prettier:
+        patterns:
+          - 'prettier'
+          - '@vkontakte/prettier-config'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     # default location of `.github/workflows`
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'
@@ -16,6 +16,19 @@ updates:
       interval: 'weekly'
     allow:
       - dependency-type: 'direct'
+    groups:
+      jest:
+        patterns:
+          - 'jest'
+          - 'jest-environment-*'
+      size-limit:
+        patterns:
+          - 'size-limit'
+          - '@size-limit/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
     reviewers:
       - 'VKCOM/vk-sec'
       - 'VKCOM/vkui-core'


### PR DESCRIPTION
## Ссылки

- [Configuration options for the dependabot.yml file • groups](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)