### PR TITLE
feat: add provenance

### DIFF
--- a/packages/icons-scripts/package.json
+++ b/packages/icons-scripts/package.json
@@ -25,5 +25,8 @@
   "packageManager": "yarn@3.6.0",
   "engines": {
     "node": ">12.0.0"
+  },
+  "publishConfig": {
+    "provenance": true
   }
 }

--- a/packages/icons-sprite/package.json
+++ b/packages/icons-sprite/package.json
@@ -61,5 +61,8 @@
       "brotli": true,
       "import": "*"
     }
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -80,5 +80,8 @@
       "gzip": false,
       "webpack": false
     }
-  ]
+  ],
+  "publishConfig": {
+    "provenance": true
+  }
 }


### PR DESCRIPTION
## Описание

Добавляем подпись от ci для npm пакетов

- [блог](https://github.blog/2023-04-19-introducing-npm-package-provenance/)
- [документация](https://docs.npmjs.com/generating-provenance-statements)

## Изменения

На пакетах появится подпись от GitHub Actions с ссылкой на коммит, процесс ci и т.д.
