### PR TITLE
Bump andresz1/size-limit-action from 1.7.0 to 1.8.0

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,9 +69,6 @@ jobs:
             See the docs for this PR at https://vkcom.github.io/icons/pull/${{ github.event.pull_request.number }}/
   size:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./packages/icons
     env:
       CI_JOB_NUMBER: 1
     steps:
@@ -85,6 +82,7 @@ jobs:
       - uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          directory: packages/icons/
           package_manager: yarn
           # only affects current branch
           skip_step: install

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -87,7 +87,7 @@ jobs:
           # only affects current branch
           skip_step: install
           build_script: 'icons-build'
-          script: yarn run size:ci
+          script: yarn run size-limit --json
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -83,6 +83,10 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           package_manager: yarn
+          # only affects current branch
+          skip_step: install
+          build_script: 'icons-build'
+          script: yarn run icons:size:ci
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -69,6 +69,9 @@ jobs:
             See the docs for this PR at https://vkcom.github.io/icons/pull/${{ github.event.pull_request.number }}/
   size:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/icons
     env:
       CI_JOB_NUMBER: 1
     steps:
@@ -86,7 +89,7 @@ jobs:
           # only affects current branch
           skip_step: install
           build_script: 'icons-build'
-          script: yarn run icons:size:ci
+          script: yarn run size:ci
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,20 +79,10 @@ jobs:
           cache: 'yarn'
       - run: YARN_ENABLE_SCRIPTS=false yarn install --immutable
       - run: yarn workspace @vkontakte/icons-sprite build
-      - uses: andresz1/size-limit-action@v1.7.0
+      - uses: andresz1/size-limit-action@v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          # only affects current branch
-          skip_step: install
-          build_script: 'icons-build'
-          # in order to call proper size-limit command during migration to yarn workspaces the script name to
-          # run size-limit has changed bacuse root icons package has been moved to /packages/icons/
-          # size-limit-action calls same script for master branch and pr branch to compare size-limit results,
-          # but master branch package.json doesn't have script from pr branch, so it falls.
-          # Here we run the new PR script with a fallback to default size-limit script
-          # when size-limit-action checkout to master to compare.
-          # TODO: Feel free to leave just 'script: yarn run icons:size:ci' once #588 released
-          script: /bin/bash -c "cat package.json | grep -q 'icons:size:ci' && yarn run icons:size:ci || npx size-limit --json"
+          package_manager: yarn
   test:
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "prettier:write": "yarn prettier --write --ignore-unknown .",
     "prettier:check": "yarn prettier --check --ignore-unknown .",
     "size": "yarn workspace @vkontakte/icons run size",
-    "g:npm:version": "cd $INIT_CWD && npm version --no-workspaces-update --no-commit-hooks --no-git-tag-version",
-    "icons-build": "cd packages/icons && yarn run icons-build",
-    "icons:size:ci": "cd packages/icons && yarn run size-limit --json"
+    "g:npm:version": "cd $INIT_CWD && npm version --no-workspaces-update --no-commit-hooks --no-git-tag-version"
   },
   "pre-commit": [
     "prettier:check"

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -21,7 +21,7 @@
     "docs": "node --max-old-space-size=4096 scripts/docs",
     "icons-build": "yarn node scripts/build-icons.js",
     "size": "yarn icons-build && yarn run size-limit",
-    "size:ci": "YARN_ENABLE_SCRIPTS=false yarn install --immutable && yarn icons-build"
+    "size:ci": "yarn run size-limit --json"
   },
   "browserslist": [
     "android >= 4.4",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -20,8 +20,7 @@
     "build": "yarn icons-build && yarn docs",
     "docs": "node --max-old-space-size=4096 scripts/docs",
     "icons-build": "yarn node scripts/build-icons.js",
-    "size": "yarn icons-build && yarn run size-limit",
-    "size:ci": "yarn run size-limit --json"
+    "size": "yarn icons-build && yarn run size-limit"
   },
   "browserslist": [
     "android >= 4.4",


### PR DESCRIPTION
Обновляем версию size-limit-action, чтобы можно было использовать свойство `package_manager` и избавиться от лишних скриптов.

Теперь вызываем size-limit-action напрямую из воркспейса `packages/icons`