### PR TITLE
fix(icons-scripts): generate es6 output in same level with es5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 .DS_Store
 dist/
+dist_es6/
 ts/
 packages/icons/docs/
 .cache

--- a/packages/icons-scripts/Readme.md
+++ b/packages/icons-scripts/Readme.md
@@ -27,9 +27,9 @@ src/
 {
   "name": "@scope/react-icons-library",
   "version": "0.0.0",
-  "files": ["dist", "src/svg"],
+  "files": ["dist", "dist_es6", "src/svg"],
   "main": "dist/index.js",
-  "module": "dist/es6/index.js",
+  "module": "dist_es6/index.js",
   "typings": "dist/typings/index.d.ts",
   "sideEffects": ["*.css"],
   "scripts": {

--- a/packages/icons-scripts/scripts/icons.js
+++ b/packages/icons-scripts/scripts/icons.js
@@ -17,6 +17,7 @@ function generateIcons(options) {
   const {
     srcDirectory,
     distDirectory,
+    distES6Directory,
     tsFilesDirectory,
     extraCategories,
     svgoPlugins,
@@ -27,7 +28,7 @@ function generateIcons(options) {
   const start = performance.now();
 
   debugInfo('Preparing directories...');
-  [distDirectory, tsFilesDirectory].forEach((dir) => {
+  [distDirectory, distES6Directory, tsFilesDirectory].forEach((dir) => {
     fs.rmSync(dir, {
       force: true,
       recursive: true,
@@ -163,7 +164,7 @@ function generateIcons(options) {
 
     debugInfo('Running swc es6...');
     execSync(
-      `swc ${tsFilesDirectory} --strip-leading-paths -d ${distDirectory}/es6/ --config-file ${swcConfig}`,
+      `swc ${tsFilesDirectory} --strip-leading-paths -d ${distES6Directory}/ --config-file ${swcConfig}`,
     );
 
     debugInfo('Running tsc...');

--- a/packages/icons-scripts/scripts/options.js
+++ b/packages/icons-scripts/scripts/options.js
@@ -49,6 +49,7 @@ function prepareOptions(options) {
   return {
     srcDirectory: directoryPath(srcDirectory),
     distDirectory: directoryPath(distDirectory),
+    distES6Directory: directoryPath(`${distDirectory}_es6`),
     keepTSSources: keepTSSources == null ? !!tsFilesDirectory : keepTSSources,
     tsFilesDirectory: tsFilesDirectory
       ? directoryPath(tsFilesDirectory)

--- a/packages/icons/.npmignore
+++ b/packages/icons/.npmignore
@@ -1,3 +1,4 @@
 *
 !/dist/**
+!/dist_es6/**
 !/src/svg/**

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -14,7 +14,7 @@
     "*.css"
   ],
   "main": "dist/index.js",
-  "module": "dist/es6/index.js",
+  "module": "dist_es6/index.js",
   "typings": "dist/typings/index.d.ts",
   "scripts": {
     "build": "yarn icons-build && yarn docs",
@@ -70,7 +70,7 @@
     },
     {
       "name": "JS ES6 with Icon16Add only import (tree shaking)",
-      "path": "dist/es6/index.js",
+      "path": "dist_es6/index.js",
       "import": "{ Icon16Add }",
       "brotli": false
     },

--- a/packages/icons/src/docs/docs.js
+++ b/packages/icons/src/docs/docs.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { aliases } from './aliases.js';
 import { HuePicker as Hue } from 'react-color';
 import './docs.css';
-import * as allIcons from '../../dist/es6';
+import * as allIcons from '../../dist_es6';
 
 const Icons = {};
 


### PR DESCRIPTION
Сейчас ES6 билд генерит файлы по вложенности на уровень ниже, но в ts файлах, которые сгенерированы для ассетов, у нас уже стоит путь чувствительный к изменению вложенности.
Теперь файлы для es6 генерятся в отдельной папке на уровне с билдом es5, причины выноса в отдельную папку:

1. Была идея класть es6 файлы рядом c es5 но с расширением mjs:
```
icon/test.js
icon/test.mjs
index.js
index.mjs
```
Но тогда при таком подходе контент js файлов должен иметь js расширения в импортах, mjs также - relative путь без расширения не подходит, потому что webpack например не понимает как такой кейс резолвить и выбрасывает ошибку. Отдельно собрать через tsc, либо swc код с проставленным расширением сейчас нельзя. 

2. Вынести es5 в dist/cjs, es6 в dist/es6 - в этом нет смысла, потому что все файлы должны лежать на уровне dist, без вложенности в подпапки. 

3. Перегонять через babel - тогда смысла держать swc нет. 

- related to #893 
