### PR TITLE
Rebuild icons-sprite on size step

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build": "yarn icons-build && yarn docs",
     "docs": "node --max-old-space-size=4096 scripts/docs",
-    "icons-build": "yarn node scripts/build-icons.js",
+    "icons-build": "yarn run -T build:icons-sprite && yarn node scripts/build-icons.js",
     "size": "yarn icons-build && yarn run size-limit"
   },
   "browserslist": [


### PR DESCRIPTION
- related #902

Пересобираем icons-sprite перед каждым запуском size-limit. 
Чтобы избежать ошибок при запуске size-limit если в PR изменились зависимости.