### PR TITLE
Little optimization for docs page

### DIFF
--- a/packages/icons/scripts/webpack.config-docs.js
+++ b/packages/icons/scripts/webpack.config-docs.js
@@ -53,7 +53,6 @@ module.exports = {
       'window.ICONS': iconsMap,
     }),
   ],
-  mode: 'development',
   cache: {
     type: 'filesystem',
   },

--- a/packages/icons/src/docs/docs.js
+++ b/packages/icons/src/docs/docs.js
@@ -111,7 +111,7 @@ class Docs extends React.PureComponent {
           <div className="color-picker">
             <Hue
               color={this.state.currentColor}
-              onChangeComplete={this.onCurrentColorChange}
+              onChange={this.onCurrentColorChange}
               width="100%"
             />
           </div>


### PR DESCRIPTION
Добавил пару небольших оптимизаций для страницы документации:
1. Для компонента ползунка изменения цвета иконок (Hue) заюзал handler onChange, потому что использовавшийся до этого onChangeComplete имеет debounce 100ms, что негативно сказывалось на скорости работы ползунка.
2. В конфиге webpack, для страницы документации, убрал проп mode=development, что бы на странице использовалась production версия react. 