### PR TITLE
fix(icons-scripts): glob on windows

### DIFF
--- a/packages/icons-scripts/scripts/icons-map.js
+++ b/packages/icons-scripts/scripts/icons-map.js
@@ -63,7 +63,7 @@ function getReplacementIconComponentName(name) {
  * @return {Icon[]}
  */
 function dirMap(src, pattern, prefix = '', deprecatedIcons) {
-  const files = sortArrayAlphabetically(glob.sync(path.join(src, `./svg/${pattern}/*.svg`)));
+  const files = sortArrayAlphabetically(glob.sync(path.posix.join(src, `./svg/${pattern}/*.svg`)));
 
   const { common, parts } = files
     .map((filepath) => {

--- a/packages/icons-scripts/scripts/icons.js
+++ b/packages/icons-scripts/scripts/icons.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const glob = require('glob');
 const { performance } = require('perf_hooks');
 const { execSync } = require('child_process');
 const { debugInfo, debugError, sortArrayAlphabetically } = require('./utils');
@@ -8,6 +9,7 @@ const { prepareOptions } = require('./options');
 const { optimize } = require('./optimize');
 const { createReactIcon } = require('./output');
 const { generateRasterIcons } = require('./raster/icons');
+const tsc = require('./tsc');
 
 /**
  * @typedef {import('./options').GenerateOptions} GenerateOptions
@@ -168,9 +170,12 @@ function generateIcons(options) {
     );
 
     debugInfo('Running tsc...');
-    execSync(
-      `tsc ${tsFilesDirectory}/**/*.ts ${tsFilesDirectory}/*.ts --emitDeclarationOnly --declaration --outDir ${distDirectory}/typings --jsx react --esModuleInterop --lib "dom,es2015" --skipLibCheck`,
-    );
+    const tsFiles = [
+      ...glob.sync(path.posix.join(tsFilesDirectory, '**', '*.ts')),
+      ...glob.sync(path.posix.join(tsFilesDirectory, '*.ts')),
+    ];
+
+    tsc.compile(tsFiles, path.join(distDirectory, 'typings'));
   };
 }
 

--- a/packages/icons-scripts/scripts/raster/icons-map.js
+++ b/packages/icons-scripts/scripts/raster/icons-map.js
@@ -17,7 +17,7 @@ const { dashToCamel, sortArrayAlphabetically } = require('../utils');
  * @param {string} src
  */
 function createIconsMap(src) {
-  const files = sortArrayAlphabetically(glob.sync(path.join(src, `./png/**/*.png`)));
+  const files = sortArrayAlphabetically(glob.sync(path.posix.join(src, `./png/**/*.png`)));
 
   /**
    * @type {Map<string, IconEntity>}

--- a/packages/icons-scripts/scripts/tsc.js
+++ b/packages/icons-scripts/scripts/tsc.js
@@ -1,0 +1,48 @@
+const ts = require('typescript');
+
+/**
+ * @type {ts.FormatDiagnosticsHost}
+ */
+const formatHost = {
+  getCanonicalFileName: (path) => path,
+  getCurrentDirectory: ts.sys.getCurrentDirectory,
+  getNewLine: () => ts.sys.newLine,
+};
+
+/**
+ * Компиляция ts файлов в js файлы
+ *
+ * @param {string[]} rootNames
+ * @param {string} outDir
+ */
+function compile(rootNames, outDir) {
+  /**
+   * @type {ts.CompilerOptions}
+   */
+  const options = {
+    outDir,
+    emitDeclarationOnly: true,
+    declaration: true,
+    jsx: 'react',
+    esModuleInterop: true,
+    skipLibCheck: true,
+  };
+
+  const program = ts.createProgram(rootNames, options);
+
+  const preEmitDiagnostics = ts.getPreEmitDiagnostics(program);
+  if (preEmitDiagnostics.length) {
+    console.log(ts.formatDiagnosticsWithColorAndContext(preEmitDiagnostics, formatHost));
+    throw new Error('Pre-Emit diagnostics failed');
+  }
+
+  const emitResult = program.emit();
+  if (emitResult.diagnostics.length) {
+    console.log(ts.formatDiagnosticsWithColorAndContext(emitResult.diagnostics, formatHost));
+    throw new Error('Compilation failed');
+  }
+
+  return emitResult;
+}
+
+module.exports = { compile };


### PR DESCRIPTION
- fixes #920

---

### Описание

Библиотека glob после обновления перестала принимать пути в windows формате. Также в командной строке windows не работают glob паттерны, поэтому tsc не срабатывает

### Изменения

- Используем для библиотеки glob пути в posix формате
- Используем typescript api вместо запуска tsc