### PR TITLE
fix(icons-scripts): fill to style color

### DIFF
--- a/packages/icons-scripts/scripts/output/react.js
+++ b/packages/icons-scripts/scripts/output/react.js
@@ -48,7 +48,7 @@ export const ${componentName}: React.FC<${componentName}Props> & ${typeAssigns} 
       viewBox={viewBox}
       width={width}
       height={height}
-      style={{color: fill, ...style}}
+      style={fill ? { color: fill, ...style } : style}
       ${attrs ? `{...${JSON.stringify(attrs)}}` : ''}
       {...restProps}
     >

--- a/packages/icons-scripts/scripts/output/react.js
+++ b/packages/icons-scripts/scripts/output/react.js
@@ -38,6 +38,8 @@ export const ${componentName}: React.FC<${componentName}Props> & ${typeAssigns} 
   height = ${height},
   viewBox = '${viewBox}',
   children,
+  style,
+  fill,
   ...restProps
 }: ${componentName}Props) => {
   return (
@@ -46,6 +48,7 @@ export const ${componentName}: React.FC<${componentName}Props> & ${typeAssigns} 
       viewBox={viewBox}
       width={width}
       height={height}
+      style={{color: fill, ...style}}
       ${attrs ? `{...${JSON.stringify(attrs)}}` : ''}
       {...restProps}
     >


### PR DESCRIPTION
- caused by #1039

---

Иконки можно было красить с помощью атрибута `fill`. Возвращаем эту возможность