### PR TITLE
fix(icons): use caret version

### DIFF
--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -36,7 +36,7 @@
   ],
   "dependencies": {
     "@swc/helpers": "^0.5.17",
-    "@vkontakte/icons-sprite": "workspace:*"
+    "@vkontakte/icons-sprite": "workspace:^"
   },
   "devDependencies": {
     "@rspack/cli": "^1.3.4",
@@ -46,7 +46,7 @@
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.11.21",
     "@types/react": "^19.0.1",
-    "@vkontakte/icons-scripts": "workspace:*",
+    "@vkontakte/icons-scripts": "workspace:^",
     "react": "^19.0.0",
     "react-color": "^2.18.0",
     "react-dom": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1970,7 +1970,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vkontakte/icons-scripts@workspace:*, @vkontakte/icons-scripts@workspace:packages/icons-scripts":
+"@vkontakte/icons-scripts@workspace:^, @vkontakte/icons-scripts@workspace:packages/icons-scripts":
   version: 0.0.0-use.local
   resolution: "@vkontakte/icons-scripts@workspace:packages/icons-scripts"
   dependencies:
@@ -1984,7 +1984,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@vkontakte/icons-sprite@workspace:*, @vkontakte/icons-sprite@workspace:packages/icons-sprite":
+"@vkontakte/icons-sprite@workspace:^, @vkontakte/icons-sprite@workspace:packages/icons-sprite":
   version: 0.0.0-use.local
   resolution: "@vkontakte/icons-sprite@workspace:packages/icons-sprite"
   dependencies:
@@ -2020,8 +2020,8 @@ __metadata:
     "@swc/core": "npm:^1.11.21"
     "@swc/helpers": "npm:^0.5.17"
     "@types/react": "npm:^19.0.1"
-    "@vkontakte/icons-scripts": "workspace:*"
-    "@vkontakte/icons-sprite": "workspace:*"
+    "@vkontakte/icons-scripts": "workspace:^"
+    "@vkontakte/icons-sprite": "workspace:^"
     react: "npm:^19.0.0"
     react-color: "npm:^2.18.0"
     react-dom: "npm:^19.0.0"


### PR DESCRIPTION
Используем каретку вместо [лока версии](https://yarnpkg.com/features/workspaces#cross-references)

```diff
- "@vkontakte/icons-scripts": "3.0.0",
+ "@vkontakte/icons-scripts": "^3.0.0",
```