### PR TITLE
ci(dependabot): rm reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
 
   - package-ecosystem: 'npm'
     directory: '/'
@@ -37,6 +34,3 @@ updates:
         patterns:
           - 'prettier'
           - '@vkontakte/prettier-config'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'


### PR DESCRIPTION
GitHub удаляет поле reviewers так как оно дублируется кодовнерством

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/