### PR TITLE
fix: fix upload artifacts step by set root working directory

### DIFF
--- a/.github/workflows/publish_icons.yml
+++ b/.github/workflows/publish_icons.yml
@@ -121,6 +121,7 @@ jobs:
           force: false
 
       - name: Prepare payload data
+        working-directory: .
         run: |
           mkdir -p publish_workflow_payload
           echo ${{ steps.git_release_tag.outputs.value }} > publish_workflow_payload/git_release_tag.txt


### PR DESCRIPTION
##   Описание

В начале publish_icons.yml установлен working_directory: packages/icons.  Из-за этого на шаге `Prepare payload data` папка  publish_workflow_payload создается в packages/icons. А на шаге `Upload payload...` папка ищется в корне.