### PR TITLE
fix(SvgIconRootV2): fix handle width and height props with undefined

### DIFF
--- a/packages/icons-sprite/src/SvgIconRootV2.tsx
+++ b/packages/icons-sprite/src/SvgIconRootV2.tsx
@@ -13,20 +13,26 @@ export function SvgIconRootV2({
   vkuiAttrs,
   children,
   vkuiProps,
+  width: widthProp,
+  height: heightProp,
+  viewBox: viewBoxProp,
   ...restProps
 }: SvgIconRootV2Props) {
-  if (typeof vkuiProps.width === 'undefined') {
-    delete vkuiProps.width;
-  }
-  if (typeof vkuiProps.height === 'undefined') {
-    delete vkuiProps.height;
-  }
+  const {
+    width: widthByUser,
+    height: heightByUser,
+    viewBox: viewBoxByUser,
+    ...restVkuiProps
+  } = vkuiProps;
 
   return (
     <SvgIconRoot
       baseClassName={`vkuiIcon--${vkuiIconId}`}
+      width={widthByUser || widthProp}
+      height={heightByUser || heightProp}
+      viewBox={viewBoxByUser || viewBoxProp}
       {...restProps}
-      {...vkuiProps}
+      {...restVkuiProps}
       style={vkuiProps.fill ? { color: vkuiProps.fill, ...vkuiProps.style } : vkuiProps.style}
       {...vkuiAttrs}
     >


### PR DESCRIPTION
- close #1233

##  Описание

При подстановке undefined в width и height в props-ы компонента в inline стили попадает запись width: 0px/height: 0px, что дает неожиданное поведение так как по логике размер не был передан

## Изменения

в `SvgIconRootV2` добавил проверку на `width` и `height` не `undefined`