### PR TITLE
fix: raster use icon size from name

### DIFF
--- a/packages/icons-scripts/scripts/raster/icons-map.js
+++ b/packages/icons-scripts/scripts/raster/icons-map.js
@@ -43,14 +43,14 @@ export function createRasterIconsMap(src) {
 
     // FIXME: async
     const buffer = fs.readFileSync(file);
-    const dimensions = imageSize(buffer);
+    const __dimensions = imageSize(buffer);
 
     const iconEntity = iconsMap.get(name) || {
       id,
       name,
       size,
-      width: dimensions.width,
-      height: dimensions.height,
+      width: size,
+      height: size,
       dirname: `${format}${path.sep}${size}`,
       componentName: getIconComponentName(name),
     };

--- a/packages/icons-sprite/src/raster/components/RasterIcon/RasterIcon.tsx
+++ b/packages/icons-sprite/src/raster/components/RasterIcon/RasterIcon.tsx
@@ -36,8 +36,8 @@ const RasterIcon = React.memo(function RasterIcon({
   getRootRef,
   id,
   size,
-  width,
-  height,
+  width = size,
+  height = size,
   className,
   ...restProps
 }: RasterIconProps) {


### PR DESCRIPTION
Оказалось у растовых изображений могут быть неверные размеры, откатываем изменения из #1366 которые влияют на размеры